### PR TITLE
add Autostart functionality

### DIFF
--- a/src/gmenu2x.cpp
+++ b/src/gmenu2x.cpp
@@ -611,11 +611,14 @@ void GMenu2X::settings() {
 	sd.addSetting(new MenuSettingBool(this, tr["Output logs"], tr["Logs the link's output to read with Log Viewer"], &confInt["outputLogs"]));
 	sd.addSetting(new MenuSettingMultiString(this, tr["Reset settings"], tr["Choose settings to reset back to defaults"], &tmp, &opFactory, 0, MakeDelegate(this, &GMenu2X::resetSettings)));
 
+	if (sd.exec() && sd.edited() && sd.save) {
+		writeConfig();
 		if (lang == "English") lang = "";
 		if (confStr["lang"] != lang) {
 			confStr["lang"] = lang;
 			tr.setLang(lang);
 		}
+	}
 
 		setBacklight(confInt["backlight"], false);
 		
@@ -1293,9 +1296,9 @@ void GMenu2X::viewAutoStart() {
 	TextDialog td(this, tr["AutoStart dialog"], tr["Last launched program's output"], "skin:icons/ebook.png");
 
 	MessageBox mb(this, tr["Disable AutoStart feature?"], "skin:icons/ebook.png");
-	mb.setButton(CONFIRM, tr["Delete"]);
+	mb.setButton(CONFIRM, tr["Disable"]);
 	mb.setButton(CANCEL,  tr["No"]);
-	mb.setButton(MODIFIER,  tr["Disable this message!"]);
+	mb.setButton(MODIFIER,  tr["Remove this message!"]);
 	int res = mb.exec();
 
 	switch (res) {

--- a/src/gmenu2x.h
+++ b/src/gmenu2x.h
@@ -155,7 +155,7 @@ public:
 	~GMenu2X();
 	void quit();
 	void quit_nosave();
-	void main();
+	void main(bool autoStart);
 	void settings();
 	void settings_date();
 	void reinit(bool showDialog = false);
@@ -172,10 +172,13 @@ public:
 
 	bool inputCommonActions(bool &inputAction);
 
+	bool autoStart;
+
 	void cls(Surface *s = NULL, bool flip = true);
 
 	void about();
 	void viewLog();
+	void viewAutoStart();
 	void contextMenu();
 	void changeWallpaper();
 	void changeSelectorDir();

--- a/src/linkapp.cpp
+++ b/src/linkapp.cpp
@@ -402,6 +402,12 @@ void LinkApp::launch(const string &selectedFile, string dir) {
 		gmenu2x->writeConfig();
 	}
 
+	if (gmenu2x->confInt["saveAutoStart"]) {
+		gmenu2x->confInt["lastCPU"] = clock;
+		gmenu2x->confStr["lastCommand"] = command.c_str();
+		gmenu2x->confStr["lastDirectory"] = dir_name(exec).c_str();
+		gmenu2x->writeConfig();
+	}
 	if (getCPU() != gmenu2x->confInt["cpuMenu"]) gmenu2x->setCPU(getCPU());
 	if (getKbdLayout() != gmenu2x->confInt["keyboardLayoutMenu"]) gmenu2x->setKbdLayout(getKbdLayout());
 


### PR DESCRIPTION
using old idea to launch directly apps after reboot with gmenu2x backend (setting brightness/cpu etc.).

Added small pop-up to disable AutoStart of particural program if you want to go back to frontend menu.

If you press to "Remove this message" the only way to return to frontend is to delete gmenu2.conf or removing there line ``dialogAutoStart=1``

![image](https://user-images.githubusercontent.com/94932128/232886050-8a5746d0-8b7c-421b-8c87-c83b385216eb.png)![image](https://user-images.githubusercontent.com/94932128/232884581-6ee8c28e-c6d9-43e6-875e-29626655bb12.png)
