### PR TITLE
 TOOLS: release gm2xpkg ver 0.10 (cfg 0.9)

### DIFF
--- a/tools/gm2xpkg.sh
+++ b/tools/gm2xpkg.sh
@@ -307,9 +307,9 @@ fi
 
 ## Generic
 HOMEPATH=${HOMEPATH:="/mnt"}
-RELEASEDIR=${RELEASEDIR:=package}
+RELEASEDIR=${RELEASEDIR:=$(mktemp -d)}
 ASSETSDIR=${ASSETSDIR:=assets}
-OPKG_ASSETSDIR=${OPKG_ASSETSDIR:=opkg_assets}
+OPKG_ASSETSDIR=${OPKG_ASSETSDIR:=$(mktemp -d)}
 LINK=${LINK:=$TARGET.lnk}
 ALIASES=${ALIASES:=aliases.txt}
 MANUAL=${MANUAL:=$TARGET.man.txt}
@@ -465,10 +465,10 @@ fi
 if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || test $IPK -eq 1 >/dev/null 2>&1; then
 	TARGET_INSTALL_DIR=$RELEASEDIR/$DESTDIR/$TARGET_DIR
 	# Create ./package
-	rm -rf $RELEASEDIR
-	mkdir -p $RELEASEDIR
-	# mkdir -p $ASSETSDIR
-	mkdir -p $OPKG_ASSETSDIR
+	rm -rf $RELEASEDIR/*
+	#mkdir -p $RELEASEDIR
+	#mkdir -p $ASSETSDIR
+	#mkdir -p $OPKG_ASSETSDIR
 	mkdir -p $TARGET_INSTALL_DIR
 	mkdir -p $RELEASEDIR/gmenu2x/sections/$SECTION
 	if test "x${FORCE}" != "xyes" || test "x${TARGET_EXIST}" == "xyes"; then

--- a/tools/gm2xpkg.sh
+++ b/tools/gm2xpkg.sh
@@ -509,7 +509,7 @@ if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || tes
 	if test -e $MANUAL; then
 		if file $MANUAL | grep -q "PNG image"; then
 			MANUAL_EXT=".man.png"
-		elif file $MANUAL | grep -q "ASCII text"; then
+		elif file $MANUAL | grep -q "text"; then
 			MANUAL_EXT=".man.txt"
 		else
 			MANUAL_EXT=""

--- a/tools/gm2xpkg.sh
+++ b/tools/gm2xpkg.sh
@@ -115,6 +115,7 @@ Depends: ${DEPENDS}\n\
 Source: ${SOURCE}\n\
 License: ${LICENSE}\n\
 Description: ${DESCRI}\n\
+Installed-Size: ${INSTALLED_SIZE}\n\
 Section: ${SECTION}\n\
 Priority: ${PRIORITY}\n\
 Maintainer: ${MAINTAINER}\n\
@@ -572,8 +573,17 @@ if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || tes
 		cp -r $OPKG_ASSETSDIR/CONTROL $RELEASEDIR
 		sed "s/^Version:.*/Version: ${VERSION}/" $OPKG_ASSETSDIR/CONTROL/control > $RELEASEDIR/CONTROL/control
 		echo 2.0 > $RELEASEDIR/debian-binary
+		#archive data
 		tar --owner=0 --group=0 -czvf $RELEASEDIR/data.tar.gz -C $RELEASEDIR/data/ . >/dev/null 2>&1
+		#archive control
+		INSTALLED_SIZE=$(zcat < $RELEASEDIR/data.tar.gz | wc -c)
+		if grep -q "Installed-Size:" $RELEASEDIR/CONTROL/control; then
+			sed -i -e "s/^Installed-Size: */Installed-Size: $INSTALLED_SIZE/" $RELEASEDIR/CONTROL/control
+		else
+			echo -e "Installed-Size: $INSTALLED_SIZE" >> $RELEASEDIR/CONTROL/control
+		fi
 		tar --owner=0 --group=0 -czvf $RELEASEDIR/control.tar.gz -C $RELEASEDIR/CONTROL/ . >/dev/null 2>&1
+		#create IPK ar archive package with gz compression
 		ar r $TARGET.ipk $RELEASEDIR/control.tar.gz $RELEASEDIR/data.tar.gz $RELEASEDIR/debian-binary\
 		 && echo "Done creating ./${TARGET}.ipk package"\
 		 && rm $RELEASEDIR/control.tar.gz $RELEASEDIR/data.tar.gz $RELEASEDIR/debian-binary && rm -r $RELEASEDIR/CONTROL/ $RELEASEDIR/data/

--- a/tools/gm2xpkg.sh
+++ b/tools/gm2xpkg.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-VER=0.9
+VER=0.10
+PKGCFG_VER=0.9
 MIYOOCFW_VER=2.0.0
 # Help & About info
 help_func() {
@@ -16,7 +17,7 @@ help_func() {
 	 \t -z, --zip       generate ZIP archive
 	 \t -p, --pkg       generate ./package
 	 \t -c, --clean     remove ./package ./opkg_assets ./<target_name>.ipk ./<target_name>.zip ./<link_name>lnk
-	 \t -g, --gencfg    generate standard config \"pkg.cfg\" file in PWD
+	 \t -g, --gencfg    generate standard config \"pkg.cfg\" v${PKGCFG_VER} file in PWD
 	 \t -f, --force     force execution even without present target's binary or incompatible .cfg version
 	 \t -q, --quiet     don't output messages to stdout
 	 Instructions:
@@ -44,7 +45,7 @@ pkg_config_func() {
 	echo "# NOTES:
 ## All variable values should be enclosed within double quotes: \"<value>\"
 ## CONFIGURATION FILE for \`gm2xpkg\` script version:
-PKGVER=\"${VER}\"
+PKGVER=\"${PKGCFG_VER}\"
 
 # EXEC commands (set to \"1\" anyone for desired outcome), you can instead use [OPTIONS] of \`gm2xpkg\`:
 PACKAGE=\"${PACKAGE}\"
@@ -199,7 +200,7 @@ do
 						echo "NO, exiting..."
 						;;
 					[Uu]*)
-						echo "Update, upgrading present ${PKGCFG} file with new config version - ${VER}"
+						echo "Update, upgrading present ${PKGCFG} file with new config version - ${PKGCFG_VER}"
 						UPDATE_PKGCFG=yes
 						pkg_config_func
 						;;
@@ -248,8 +249,8 @@ if test -f "${PKGCFG}"; then
 		echo "<<<EOF>>>"
 	fi
 	source "${PKGCFG}"
-	if test "${VER}" != "${PKGVER}" ; then
-		echo -e "ERROR: GM2X PACKAGER version ${VER} doesn't match CONFIGURATION FILE version ${PKGVER}\n\n\tPlease update your ${PKGCFG} config file, use [--gencfg] option\n"
+	if test "${PKGCFG_VER}" != "${PKGVER}" ; then
+		echo -e "ERROR: GM2X PACKAGER CFG version ${PKGCFG_VER} doesn't match CONFIGURATION FILE version ${PKGVER}\n\n\tPlease update your ${PKGCFG} config file, use [--gencfg] option\n"
 		if test "x${FORCE}" == "xyes"; then
 			echo "WARNING: Force-mode active, running regardless deprecated/incompatible ${PKGCFG}."
 		else

--- a/tools/gm2xpkg.sh
+++ b/tools/gm2xpkg.sh
@@ -472,8 +472,9 @@ if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || tes
 	#mkdir -p $OPKG_ASSETSDIR
 	mkdir -p $TARGET_INSTALL_DIR
 	mkdir -p $RELEASEDIR/gmenu2x/sections/$SECTION
-	test -n "$SELDIR" \
-	 && mkdir -p ${RELEASEDIR}${SELDIR}
+	# TODO: wait for patch in opkg or fix symlink deletion when unistalling ipk
+	#test -n "$SELDIR" \
+	#&& mkdir -p ${RELEASEDIR}${SELDIR}
 	if test "x${FORCE}" != "xyes" || test "x${TARGET_EXIST}" == "xyes"; then
 		cp $TARGET_PATH $TARGET_INSTALL_DIR/
 	else
@@ -555,8 +556,14 @@ if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || tes
 		mv $RELEASEDIR$HOMEPATH $RELEASEDIR/data/
 		if ! { test -d ${OPKG_ASSETSDIR}/CONTROL && test -f ${OPKG_ASSETSDIR}/CONTROL/preinst && test -f ${OPKG_ASSETSDIR}/CONTROL/postinst && test -f ${OPKG_ASSETSDIR}/CONTROL/control; }; then
 			mkdir -p $OPKG_ASSETSDIR/CONTROL
+			#preinst script
 			echo -e "#!/bin/sh\nsync; echo 'Installing new ${TARGET}..'; rm /var/lib/opkg/info/${TARGET}.list; exit 0" > $OPKG_ASSETSDIR/CONTROL/preinst
-			echo -e "#!/bin/sh\nsync; echo 'Installation finished.'; echo 'Restarting ${TARGET}..'; sleep 1; killall ${TARGET}; exit 0" > $OPKG_ASSETSDIR/CONTROL/postinst
+			#postinst script
+			echo -e "#!/bin/sh\nsync;" >> $OPKG_ASSETSDIR/CONTROL/postinst
+			test -n "$SELDIR" \
+			 && echo -e "! test -d ${SELDIR} && mkdir -p ${SELDIR} && echo 'Created ${SELDIR} dir for Selector.';" >> $OPKG_ASSETSDIR/CONTROL/postinst
+			echo -e "echo 'Installation finished.'; echo 'Restarting ${TARGET}..'; sleep 1; killall ${TARGET}; exit 0" >> $OPKG_ASSETSDIR/CONTROL/postinst
+			#control file
 			echo -e $CONTROL > $OPKG_ASSETSDIR/CONTROL/control
 		else
 			OPKG_ASSETSDIR_CUSTOM="yes"

--- a/tools/gm2xpkg.sh
+++ b/tools/gm2xpkg.sh
@@ -115,7 +115,6 @@ Depends: ${DEPENDS}\n\
 Source: ${SOURCE}\n\
 License: ${LICENSE}\n\
 Description: ${DESCRI}\n\
-Installed-Size: ${INSTALLED_SIZE}\n\
 Section: ${SECTION}\n\
 Priority: ${PRIORITY}\n\
 Maintainer: ${MAINTAINER}\n\
@@ -573,17 +572,8 @@ if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || tes
 		cp -r $OPKG_ASSETSDIR/CONTROL $RELEASEDIR
 		sed "s/^Version:.*/Version: ${VERSION}/" $OPKG_ASSETSDIR/CONTROL/control > $RELEASEDIR/CONTROL/control
 		echo 2.0 > $RELEASEDIR/debian-binary
-		#archive data
 		tar --owner=0 --group=0 -czvf $RELEASEDIR/data.tar.gz -C $RELEASEDIR/data/ . >/dev/null 2>&1
-		#archive control
-		INSTALLED_SIZE=$(zcat < $RELEASEDIR/data.tar.gz | wc -c)
-		if grep -q "Installed-Size:" $RELEASEDIR/CONTROL/control; then
-			sed -i -e "s/^Installed-Size: */Installed-Size: $INSTALLED_SIZE/" $RELEASEDIR/CONTROL/control
-		else
-			echo -e "Installed-Size: $INSTALLED_SIZE" >> $RELEASEDIR/CONTROL/control
-		fi
 		tar --owner=0 --group=0 -czvf $RELEASEDIR/control.tar.gz -C $RELEASEDIR/CONTROL/ . >/dev/null 2>&1
-		#create IPK ar archive package with gz compression
 		ar r $TARGET.ipk $RELEASEDIR/control.tar.gz $RELEASEDIR/data.tar.gz $RELEASEDIR/debian-binary\
 		 && echo "Done creating ./${TARGET}.ipk package"\
 		 && rm $RELEASEDIR/control.tar.gz $RELEASEDIR/data.tar.gz $RELEASEDIR/debian-binary && rm -r $RELEASEDIR/CONTROL/ $RELEASEDIR/data/

--- a/tools/gm2xpkg.sh
+++ b/tools/gm2xpkg.sh
@@ -466,12 +466,14 @@ fi
 if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || test $IPK -eq 1 >/dev/null 2>&1; then
 	TARGET_INSTALL_DIR=$RELEASEDIR/$DESTDIR/$TARGET_DIR
 	# Create ./package
-	rm -rf $RELEASEDIR/*
+	rm -rf "${RELEASEDIR:?}"/*
 	#mkdir -p $RELEASEDIR
 	#mkdir -p $ASSETSDIR
 	#mkdir -p $OPKG_ASSETSDIR
 	mkdir -p $TARGET_INSTALL_DIR
 	mkdir -p $RELEASEDIR/gmenu2x/sections/$SECTION
+	test -n "$SELDIR" \
+	 && mkdir -p ${RELEASEDIR}${SELDIR}
 	if test "x${FORCE}" != "xyes" || test "x${TARGET_EXIST}" == "xyes"; then
 		cp $TARGET_PATH $TARGET_INSTALL_DIR/
 	else
@@ -530,9 +532,9 @@ if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || tes
 		done
 	fi
 	if test -d $RELEASEDIR/gmenu2x && test -d $TARGET_INSTALL_DIR; then
-	 	test $PACKAGE -eq 1 && echo "Done packaging ./$RELEASEDIR/ data" || echo "Ready to use ./$RELEASEDIR/ data for deaper packaging"
+	 	test $PACKAGE -eq 1 && echo "Done packaging $RELEASEDIR data" || echo "Ready to use $RELEASEDIR/ data for deaper packaging"
 	else
-		echo "WARNING: Upss smth went wrong and I couldn't locate auto-gen data in ./$RELEASEDIR/"
+		echo "WARNING: Upss smth went wrong and I couldn't locate auto-gen data in $RELEASEDIR/"
 	fi
 	
 	# Create ./package/<target_version>.zip
@@ -547,8 +549,8 @@ if test $PACKAGE -eq 1 >/dev/null 2>&1 || test $ZIP -eq 1 >/dev/null 2>&1 || tes
 	# Create ./package/<target>.ipk
 	if test $IPK -eq 1 >/dev/null 2>&1; then
 		# rm -rf $RELEASEDIR/*.ipk $RELEASEDIR/*.zip
-		mkdir -p .$HOMEPATH
-		cp -r $RELEASEDIR/* .$HOMEPATH && mv .$HOMEPATH $RELEASEDIR/
+		mkdir -p $RELEASEDIR/$HOMEPATH
+		for f in $RELEASEDIR/*; do test "$f" != "${RELEASEDIR}${HOMEPATH}" && mv "$f" $RELEASEDIR/$HOMEPATH; done
 		mkdir -p $RELEASEDIR/data
 		mv $RELEASEDIR$HOMEPATH $RELEASEDIR/data/
 		if ! { test -d ${OPKG_ASSETSDIR}/CONTROL && test -f ${OPKG_ASSETSDIR}/CONTROL/preinst && test -f ${OPKG_ASSETSDIR}/CONTROL/postinst && test -f ${OPKG_ASSETSDIR}/CONTROL/control; }; then


### PR DESCRIPTION
- bisect gm2xpkg with $VER and cfg ver. with $PKGCFG_VER
- use tmp path for default $RELEASEDIR $OPKG_ASSETSDIR
- allow MANUAL to be another type e.g. Unicode text
- use `postinst` for mkdir $SELDIR (workaround for symlink deletion in OPKG, but leaves blank dir after uninstall)